### PR TITLE
Remove GameRegistry of Blocks with items that are registered later

### DIFF
--- a/carpentersblocks/util/handler/BlockHandler.java
+++ b/carpentersblocks/util/handler/BlockHandler.java
@@ -185,7 +185,7 @@ public class BlockHandler
     	
     	if (enableBed) {
         	blockCarpentersBed = (new BlockCarpentersBed(blockCarpentersBedID));
-    		GameRegistry.registerBlock(blockCarpentersBed, "blockCarpentersBed");
+    		//GameRegistry.registerBlock(blockCarpentersBed, "blockCarpentersBed");
         }
     	
     	if (enableBlock) {
@@ -208,7 +208,7 @@ public class BlockHandler
     	
     	if (enableDoor) {
     		blockCarpentersDoor = (new BlockCarpentersDoor(blockCarpentersDoorID));
-    		GameRegistry.registerBlock(blockCarpentersDoor, "blockCarpentersDoor");
+    		//GameRegistry.registerBlock(blockCarpentersDoor, "blockCarpentersDoor");
         }
     	
     	if (enableGate) {


### PR DESCRIPTION
This function is only meant to create an item for the block. Since you are using the custom Item class you don't need to do it here.
