### PR TITLE
Automatically create and rename a zip file in /build/

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,3 +60,18 @@ processResources
         exclude 'mcmod.info'
     }
 }
+
+task rename(type: Copy) {
+    from('build/libs/')
+    rename { String fileName ->
+        if (fileName.endsWith('jar')) {
+            String minecraftVersion = project.minecraft.version
+            String newMinecraftVersion = minecraftVersion.split("-")[0]
+            String newName = "Carpenter's Blocks v" + project.version + " - MC " + newMinecraftVersion + ".zip"
+            newName
+        }
+    }
+    into('build/')
+}
+
+build.dependsOn rename


### PR DESCRIPTION
This is currently built to what is standard in your website downloads, and will automatically change version numbers as they change

Fixes #106

Signed-off-by: Cruz Julian Bishop cruz@techern.com
