### PR TITLE
Added getValidRotations and rotateBlock support

### DIFF
--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersDoor.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersDoor.java
@@ -94,56 +94,56 @@ public class BlockCarpentersDoor extends BlockHinged {
         return BlockRegistry.carpentersDoorRenderID;
     }
     
-@Override
-public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
-{
-	ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
-	return axises;
-}
-
-@Override
-public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
-{
-	// to correctly support archimedes' ships mod:
-	// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
-	// if Axis is UP, block rotates to the right:  north -> east -> south -> west
-	
-	TileEntity tile = world.getTileEntity(x, y, z);
-	if (tile != null && tile instanceof TEBase)
+	@Override
+	public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
 	{
-		TEBase cbTile = (TEBase)tile;
-		int direction = Hinge.getFacing(cbTile);
-		switch (axis)
-		{
-			case UP: 
-			{
-				switch (direction)
-				{
-					case 0:{Hinge.setFacing(cbTile, 1); break;}
-					case 1:{Hinge.setFacing(cbTile, 2); break;}
-					case 2:{Hinge.setFacing(cbTile, 3); break;}
-					case 3:{Hinge.setFacing(cbTile, 0); break;}
-					default: return false;
-				}
-				break;
-			}
-			case DOWN:
-			{
-				switch (direction)
-				{
-					case 0:{Hinge.setFacing(cbTile, 3); break;}
-					case 1:{Hinge.setFacing(cbTile, 0); break;}
-					case 2:{Hinge.setFacing(cbTile, 1); break;}
-					case 3:{Hinge.setFacing(cbTile, 2); break;}
-					default: return false;
-				}
-				break;
-			}
-			default: return false;
-		}
-		return true;
+		ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
+		return axises;
 	}
-	return false;
-}
+	
+	@Override
+	public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
+	{
+		// to correctly support archimedes' ships mod:
+		// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
+		// if Axis is UP, block rotates to the right:  north -> east -> south -> west
+		
+		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile != null && tile instanceof TEBase)
+		{
+			TEBase cbTile = (TEBase)tile;
+			int direction = Hinge.getFacing(cbTile);
+			switch (axis)
+			{
+				case UP: 
+				{
+					switch (direction)
+					{
+						case 0:{Hinge.setFacing(cbTile, 1); break;}
+						case 1:{Hinge.setFacing(cbTile, 2); break;}
+						case 2:{Hinge.setFacing(cbTile, 3); break;}
+						case 3:{Hinge.setFacing(cbTile, 0); break;}
+						default: return false;
+					}
+					break;
+				}
+				case DOWN:
+				{
+					switch (direction)
+					{
+						case 0:{Hinge.setFacing(cbTile, 3); break;}
+						case 1:{Hinge.setFacing(cbTile, 0); break;}
+						case 2:{Hinge.setFacing(cbTile, 1); break;}
+						case 3:{Hinge.setFacing(cbTile, 2); break;}
+						default: return false;
+					}
+					break;
+				}
+				default: return false;
+			}
+			return true;
+		}
+		return false;
+	}
 
 }

--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersGate.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersGate.java
@@ -285,34 +285,34 @@ public class BlockCarpentersGate extends BlockCoverable {
         return BlockRegistry.carpentersGateRenderID;
     }
     
-@Override
-public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
-{
-	ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
-	return axises;
-}
-
-@Override
-public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
-{
-	// to correctly support archimedes' ships mod:
-	// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
-	// if Axis is UP, block rotates to the right:  north -> east -> south -> west
-	
-	TileEntity tile = world.getTileEntity(x, y, z);
-	if (tile != null && tile instanceof TEBase)
+	@Override
+	public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
 	{
-		TEBase cbTile = (TEBase)tile;
-		int facing = Gate.getFacing(cbTile);
-		switch (facing)
-		{
-			case 0:{Gate.setFacing(cbTile, 1); break;}
-			case 1:{Gate.setFacing(cbTile, 0); break;}
-			default: return false;
-		}
-		return true;
+		ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
+		return axises;
 	}
-	return false;
-}
+	
+	@Override
+	public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
+	{
+		// to correctly support archimedes' ships mod:
+		// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
+		// if Axis is UP, block rotates to the right:  north -> east -> south -> west
+		
+		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile != null && tile instanceof TEBase)
+		{
+			TEBase cbTile = (TEBase)tile;
+			int facing = Gate.getFacing(cbTile);
+			switch (facing)
+			{
+				case 0:{Gate.setFacing(cbTile, 1); break;}
+				case 1:{Gate.setFacing(cbTile, 0); break;}
+				default: return false;
+			}
+			return true;
+		}
+		return false;
+	}
 
 }

--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersHatch.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersHatch.java
@@ -377,54 +377,54 @@ public class BlockCarpentersHatch extends BlockCoverable {
         return BlockRegistry.carpentersHatchRenderID;
     }
     
-@Override
-public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
-{
-	ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
-	return axises;
-}
-
-@Override
-public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
-{
-	// to correctly support archimedes' ships mod:
-	// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
-	// if Axis is UP, block rotates to the right:  north -> east -> south -> west
-	
-	TileEntity tile = world.getTileEntity(x, y, z);
-	if (tile != null && tile instanceof TEBase)
+	@Override
+	public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
 	{
-		TEBase cbTile = (TEBase)tile;
-		int direction = Hatch.getDir(cbTile);
-		switch (axis)
-		{
-			case UP:
-			{
-				switch (direction)
-				{
-					case 0:{Hatch.setDir(cbTile, 3); break;}
-					case 1:{Hatch.setDir(cbTile, 2); break;}
-					case 2:{Hatch.setDir(cbTile, 0); break;}
-					case 3:{Hatch.setDir(cbTile, 1); break;}
-				}
-				break;
-			}
-			case DOWN:
-			{
-				switch (direction)
-				{
-					case 0:{Hatch.setDir(cbTile, 2); break;}
-					case 1:{Hatch.setDir(cbTile, 3); break;}
-					case 2:{Hatch.setDir(cbTile, 1); break;}
-					case 3:{Hatch.setDir(cbTile, 0); break;}
-				}
-				break;
-			}
-			default: return false;
-		}
-		return true;
+		ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
+		return axises;
 	}
-	return false;
-}
+	
+	@Override
+	public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
+	{
+		// to correctly support archimedes' ships mod:
+		// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
+		// if Axis is UP, block rotates to the right:  north -> east -> south -> west
+		
+		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile != null && tile instanceof TEBase)
+		{
+			TEBase cbTile = (TEBase)tile;
+			int direction = Hatch.getDir(cbTile);
+			switch (axis)
+			{
+				case UP:
+				{
+					switch (direction)
+					{
+						case 0:{Hatch.setDir(cbTile, 3); break;}
+						case 1:{Hatch.setDir(cbTile, 2); break;}
+						case 2:{Hatch.setDir(cbTile, 0); break;}
+						case 3:{Hatch.setDir(cbTile, 1); break;}
+					}
+					break;
+				}
+				case DOWN:
+				{
+					switch (direction)
+					{
+						case 0:{Hatch.setDir(cbTile, 2); break;}
+						case 1:{Hatch.setDir(cbTile, 3); break;}
+						case 2:{Hatch.setDir(cbTile, 1); break;}
+						case 3:{Hatch.setDir(cbTile, 0); break;}
+					}
+					break;
+				}
+				default: return false;
+			}
+			return true;
+		}
+		return false;
+	}
 
 }

--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersLadder.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersLadder.java
@@ -157,35 +157,35 @@ public class BlockCarpentersLadder extends BlockSided {
         return BlockRegistry.carpentersLadderRenderID;
     }
     
-@Override
-public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
-{
-	ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
-	return axises;
-}
-
-@Override
-public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
-{
-	// to correctly support archimedes' ships mod:
-	// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
-	// if Axis is UP, block rotates to the right:  north -> east -> south -> west
-	
-	TileEntity tile = world.getTileEntity(x, y, z);
-	if (tile != null && tile instanceof TEBase)
+	@Override
+	public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
 	{
-		TEBase cbTile = (TEBase)tile;
-		int data = cbTile.getData();
-		int dataAngle = data % 2;
-		switch (dataAngle)
-		{
-			case 0:{cbTile.setData(data+1); break;}
-			case 1:{cbTile.setData(data-1); break;}
-			default:return false;
-		}
-		return true;
+		ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
+		return axises;
 	}
-	return false;
-}
+	
+	@Override
+	public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
+	{
+		// to correctly support archimedes' ships mod:
+		// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
+		// if Axis is UP, block rotates to the right:  north -> east -> south -> west
+		
+		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile != null && tile instanceof TEBase)
+		{
+			TEBase cbTile = (TEBase)tile;
+			int data = cbTile.getData();
+			int dataAngle = data % 2;
+			switch (dataAngle)
+			{
+				case 0:{cbTile.setData(data+1); break;}
+				case 1:{cbTile.setData(data-1); break;}
+				default:return false;
+			}
+			return true;
+		}
+		return false;
+	}
 
 }

--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersSafe.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersSafe.java
@@ -300,56 +300,56 @@ public class BlockCarpentersSafe extends BlockCoverable {
         return BlockRegistry.carpentersSafeRenderID;
     }
     
-@Override
-public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
-{
-	ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
-	return axises;
-}
-
-@Override
-public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
-{
-	// to correctly support archimedes' ships mod:
-	// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
-	// if Axis is UP, block rotates to the right:  north -> east -> south -> west
-	
-	TileEntity tile = world.getTileEntity(x, y, z);
-	if (tile != null && tile instanceof TEBase)
+	@Override
+	public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
 	{
-		TEBase cbTile = (TEBase)tile;
-		ForgeDirection direction = Safe.getFacing(cbTile);
-		switch (axis)
-		{
-			case UP:
-			{
-				switch (direction)
-				{
-					case NORTH:{Safe.setFacing(cbTile, 1); break;}
-					case EAST:{Safe.setFacing(cbTile, 2); break;}
-					case WEST:{Safe.setFacing(cbTile, 3); break;}
-					case SOUTH:{Safe.setFacing(cbTile, 0); break;}
-					default: break;
-				}
-				break;
-			}
-			case DOWN:
-			{
-				switch (direction)
-				{
-					case NORTH:{Safe.setFacing(cbTile, 3); break;}
-					case EAST:{Safe.setFacing(cbTile, 0); break;}
-					case SOUTH:{Safe.setFacing(cbTile, 1); break;}
-					case WEST:{Safe.setFacing(cbTile, 2); break;}
-					default: break;
-				}
-				break;
-			}
-			default: return false;
-		}
-		return true;
+		ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
+		return axises;
 	}
-	return false;
-}
+	
+	@Override
+	public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
+	{
+		// to correctly support archimedes' ships mod:
+		// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
+		// if Axis is UP, block rotates to the right:  north -> east -> south -> west
+		
+		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile != null && tile instanceof TEBase)
+		{
+			TEBase cbTile = (TEBase)tile;
+			ForgeDirection direction = Safe.getFacing(cbTile);
+			switch (axis)
+			{
+				case UP:
+				{
+					switch (direction)
+					{
+						case NORTH:{Safe.setFacing(cbTile, 1); break;}
+						case EAST:{Safe.setFacing(cbTile, 2); break;}
+						case WEST:{Safe.setFacing(cbTile, 3); break;}
+						case SOUTH:{Safe.setFacing(cbTile, 0); break;}
+						default: break;
+					}
+					break;
+				}
+				case DOWN:
+				{
+					switch (direction)
+					{
+						case NORTH:{Safe.setFacing(cbTile, 3); break;}
+						case EAST:{Safe.setFacing(cbTile, 0); break;}
+						case SOUTH:{Safe.setFacing(cbTile, 1); break;}
+						case WEST:{Safe.setFacing(cbTile, 2); break;}
+						default: break;
+					}
+					break;
+				}
+				default: return false;
+			}
+			return true;
+		}
+		return false;
+	}
 
 }

--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersSlope.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersSlope.java
@@ -682,55 +682,55 @@ public class BlockCarpentersSlope extends BlockCoverable {
         return BlockRegistry.carpentersSlopeRenderID;
     }
     
-@Override
-public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
-{
-	ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
-	return axises;
-}
-
-@Override
-public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
-{
-	// to correctly support archimedes' ships mod:
-	// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
-	// if Axis is UP, block rotates to the right:  north -> east -> south -> west
-	
-	TileEntity tile = world.getTileEntity(x, y, z);
-	if (tile != null && tile instanceof TEBase)
+	@Override
+	public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
 	{
-		TEBase cbTile = (TEBase)tile;
-		int data = cbTile.getData();
-		int dataAngle = data % 4;
-		switch (axis)
-		{
-			case UP:
-			{
-				switch (dataAngle)
-				{
-					case 0:{cbTile.setData(data+3); break;}
-					case 1:{cbTile.setData(data+1); break;}
-					case 2:{cbTile.setData(data-2); break;}
-					case 3:{cbTile.setData(data-2); break;}
-				}
-				break;
-			}
-			case DOWN:
-			{
-				switch (dataAngle)
-				{
-					case 0:{cbTile.setData(data+2); break;}
-					case 1:{cbTile.setData(data+2); break;}
-					case 2:{cbTile.setData(data-1); break;}
-					case 3:{cbTile.setData(data-3); break;}
-				}
-				break;
-			}
-			default: return false;
-		}
-		return true;
+		ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
+		return axises;
 	}
-	return false;
-}
+	
+	@Override
+	public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
+	{
+		// to correctly support archimedes' ships mod:
+		// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
+		// if Axis is UP, block rotates to the right:  north -> east -> south -> west
+		
+		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile != null && tile instanceof TEBase)
+		{
+			TEBase cbTile = (TEBase)tile;
+			int data = cbTile.getData();
+			int dataAngle = data % 4;
+			switch (axis)
+			{
+				case UP:
+				{
+					switch (dataAngle)
+					{
+						case 0:{cbTile.setData(data+3); break;}
+						case 1:{cbTile.setData(data+1); break;}
+						case 2:{cbTile.setData(data-2); break;}
+						case 3:{cbTile.setData(data-2); break;}
+					}
+					break;
+				}
+				case DOWN:
+				{
+					switch (dataAngle)
+					{
+						case 0:{cbTile.setData(data+2); break;}
+						case 1:{cbTile.setData(data+2); break;}
+						case 2:{cbTile.setData(data-1); break;}
+						case 3:{cbTile.setData(data-3); break;}
+					}
+					break;
+				}
+				default: return false;
+			}
+			return true;
+		}
+		return false;
+	}
 
 }

--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersStairs.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersStairs.java
@@ -361,55 +361,55 @@ public class BlockCarpentersStairs extends BlockCoverable {
         return BlockRegistry.carpentersStairsRenderID;
     }
     
-@Override
-public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
-{
-	ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
-	return axises;
-}
-
-@Override
-public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
-{
-	// to correctly support archimedes' ships mod:
-	// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
-	// if Axis is UP, block rotates to the right:  north -> east -> south -> west
-	
-	TileEntity tile = world.getTileEntity(x, y, z);
-	if (tile != null && tile instanceof TEBase)
+	@Override
+	public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
 	{
-		TEBase cbTile = (TEBase)tile;
-		int data = cbTile.getData();
-		int dataAngle = data % 4;
-		switch (axis)
-		{
-			case UP:
-			{
-				switch (dataAngle)
-				{
-					case 0:{cbTile.setData(data+3); break;}
-					case 1:{cbTile.setData(data+1); break;}
-					case 2:{cbTile.setData(data-2); break;}
-					case 3:{cbTile.setData(data-2); break;}
-				}
-				break;
-			}
-			case DOWN:
-			{
-				switch (dataAngle)
-				{
-					case 0:{cbTile.setData(data+2); break;}
-					case 1:{cbTile.setData(data+2); break;}
-					case 2:{cbTile.setData(data-1); break;}
-					case 3:{cbTile.setData(data-3); break;}
-				}
-				break;
-			}
-			default: return false;
-		}
-		return true;
+		ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
+		return axises;
 	}
-	return false;
-}
+	
+	@Override
+	public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
+	{
+		// to correctly support archimedes' ships mod:
+		// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
+		// if Axis is UP, block rotates to the right:  north -> east -> south -> west
+		
+		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile != null && tile instanceof TEBase)
+		{
+			TEBase cbTile = (TEBase)tile;
+			int data = cbTile.getData();
+			int dataAngle = data % 4;
+			switch (axis)
+			{
+				case UP:
+				{
+					switch (dataAngle)
+					{
+						case 0:{cbTile.setData(data+3); break;}
+						case 1:{cbTile.setData(data+1); break;}
+						case 2:{cbTile.setData(data-2); break;}
+						case 3:{cbTile.setData(data-2); break;}
+					}
+					break;
+				}
+				case DOWN:
+				{
+					switch (dataAngle)
+					{
+						case 0:{cbTile.setData(data+2); break;}
+						case 1:{cbTile.setData(data+2); break;}
+						case 2:{cbTile.setData(data-1); break;}
+						case 3:{cbTile.setData(data-3); break;}
+					}
+					break;
+				}
+				default: return false;
+			}
+			return true;
+		}
+		return false;
+	}
 
 }


### PR DESCRIPTION
Since I was familiar with getting blocks to rotate with Archimedes' Ships from my work on BiblioCraft, I figured I would help out here with carpenters blocks.

Overriding these 2 methods in the block class allows other mods to rotate carpenters blocks via vanilla methods. A prime example would be Archimedes' Ships, which uses these methods to rotate blocks when the ships rotate, which is the main motivator for me adding this. 

I added support to the slopes, stairs, ladders, doors, safes, hatches and gates. I compiled out and tested on a server and just a client with the Archimedes' Ships mod and they all seem to rotate correctly with the ships now. The only other 2 blocks I think that could possibly use this treatment are the bed and the garage door. 

Each block had to be implemented a little differently due to the variation (lack of consistency) in ways available to rotate / change facing / direction of the blocks. It seems to work good though the way I implemented it, so its all good. 
