### PR TITLE
Added rotateBlock to Bed and Garage Door

### DIFF
--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersBed.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersBed.java
@@ -10,10 +10,13 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayer.EnumStatus;
 import net.minecraft.item.Item;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
+import net.minecraftforge.common.util.ForgeDirection;
+
 import com.carpentersblocks.CarpentersBlocks;
 import com.carpentersblocks.data.Bed;
 import com.carpentersblocks.tileentity.TEBase;
@@ -266,5 +269,58 @@ public class BlockCarpentersBed extends BlockCoverable {
     {
         return BlockRegistry.carpentersBedRenderID;
     }
+    
+	@Override
+	public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
+	{
+		ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
+		return axises;
+	}
+	
+	@Override
+	public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
+	{
+		// to correctly support archimedes' ships mod:
+		// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
+		// if Axis is UP, block rotates to the right:  north -> east -> south -> west
+		
+		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile != null && tile instanceof TEBase)
+		{
+			TEBase cbTile = (TEBase)tile;
+			ForgeDirection direction = Bed.getDirection(cbTile);
+			switch (axis)
+			{
+				case UP:
+				{
+					switch (direction)
+					{
+						case NORTH:{Bed.setDirection(cbTile, 1); break;}
+						case EAST:{Bed.setDirection(cbTile, 2); break;}
+						case SOUTH:{Bed.setDirection(cbTile, 3); break;}
+						case WEST:{Bed.setDirection(cbTile, 0); break;}
+						default: break;
+					}
+					break;
+				}
+				case DOWN:
+				{
+					switch (direction)
+					{
+						case NORTH:{Bed.setDirection(cbTile, 3); break;}
+						case EAST:{Bed.setDirection(cbTile, 0); break;}
+						case SOUTH:{Bed.setDirection(cbTile, 1); break;}
+						case WEST:{Bed.setDirection(cbTile, 2); break;}
+						default: break;
+					}
+					break;
+				}
+				default: return false;
+			}
+			return true;
+		}
+		return false;
+	}
+
 
 }

--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersGarageDoor.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersGarageDoor.java
@@ -7,6 +7,7 @@ import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
@@ -433,5 +434,62 @@ public class BlockCarpentersGarageDoor extends BlockCoverable {
     {
         return BlockRegistry.carpentersGarageDoorRenderID;
     }
+    
+	@Override
+	public ForgeDirection[] getValidRotations(World worldObj, int x, int y,int z) 
+	{
+		ForgeDirection[] axises = {ForgeDirection.UP, ForgeDirection.DOWN};
+		return axises;
+	}
+	
+	@Override
+	public boolean rotateBlock(World world, int x, int y, int z, ForgeDirection axis) 
+	{
+		// to correctly support archimedes' ships mod:
+		// if Axis is DOWN, block rotates to the left, north -> west -> south -> east
+		// if Axis is UP, block rotates to the right:  north -> east -> south -> west
+		
+		TileEntity tile = world.getTileEntity(x, y, z);
+		if (tile != null && tile instanceof TEBase)
+		{
+			TEBase cbTile = (TEBase)tile;
+			int dataAngle = (cbTile.getData() & 0x70) >> 4;
+        	ForgeDirection direction = ForgeDirection.getOrientation(dataAngle);
+        	int newAngle = 0;
+        	
+			switch (axis)
+			{
+				case UP:
+				{
+					switch (direction)
+					{
+						case WEST:{newAngle = (cbTile.getData() & ~0x70) | (ForgeDirection.NORTH.ordinal() << 4); break;}
+						case NORTH:{newAngle = (cbTile.getData() & ~0x70) | (ForgeDirection.EAST.ordinal() << 4); break;}
+						case EAST:{newAngle = (cbTile.getData() & ~0x70) | (ForgeDirection.SOUTH.ordinal() << 4); break;}
+						case SOUTH:{newAngle = (cbTile.getData() & ~0x70) | (ForgeDirection.WEST.ordinal() << 4); break;}
+						default: break;
+					}
+					cbTile.setData(newAngle);
+					return true;
+				}
+				case DOWN:
+				{
+					switch (direction)
+					{
+						case WEST:{newAngle = (cbTile.getData() & ~0x70) | (ForgeDirection.SOUTH.ordinal() << 4); break;}
+						case NORTH:{newAngle = (cbTile.getData() & ~0x70) | (ForgeDirection.EAST.ordinal() << 4); break;}
+						case EAST:{newAngle = (cbTile.getData() & ~0x70) | (ForgeDirection.NORTH.ordinal() << 4); break;}
+						case SOUTH:{newAngle = (cbTile.getData() & ~0x70) | (ForgeDirection.WEST.ordinal() << 4); break;}
+						default: break;
+					}
+					cbTile.setData(newAngle);
+					return true;
+				}
+				default: return false;
+			}
+		}
+		
+		return false;
+	}
 
 }


### PR DESCRIPTION
Added the rotateBlock methods to the bed and the garage door. I think that is the rest of the blocks that need to rotate with the ships mod. I compiled and tested both SSP and SMP a little bit too with no issues.

There is one major issue I found with the garage door on ships though. If a garage door is 2 or more blocks tall and it is open when you mount a ship, terrible things happens. The console will start spitting GL ERROR and the game screen will start flashing and become graphicly unresponsive. I presume the issue is when the ships mod  tries to render the invisible blocks from the open garage door. I suspect this might be an issue that needs to be solved on the Archimedes' Ships side. This issue seems to exists before the changes I made, I double checked just to make sure. I'll create an issue on the ships mod github and mention this. 
