### PR TITLE
Add color wrapper

### DIFF
--- a/src/main/java/com/carpentersblocks/block/BlockCoverable.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCoverable.java
@@ -1216,6 +1216,20 @@ public class BlockCoverable extends BlockContainer {
             return super.getPlayerRelativeBlockHardness(entityPlayer, world, x, y, z);
         }
     }
+    
+    public int colorMultiplier(IBlockAccess iba, int x, int y, int z) {
+        TEBase TE = getTileEntity(iba, x, y, z);
+        if (TE != null) {
+            ItemStack is = BlockProperties.getCoverForRendering(TE, 6);
+            if (is != null) {
+                Block b = BlockProperties.toBlock(is);
+                if (b != null) {
+                    return b.colorMultiplier(iba, x, y, z);
+                }
+            }
+        }
+        return super.colorMultiplier(iba, x, y, z);
+    }
 
     @Override
     @SideOnly(Side.CLIENT)

--- a/src/main/java/com/carpentersblocks/block/BlockCoverable.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCoverable.java
@@ -1217,6 +1217,8 @@ public class BlockCoverable extends BlockContainer {
         }
     }
     
+    @SideOnly(Side.CLIENT)
+    @Override
     public int colorMultiplier(IBlockAccess iba, int x, int y, int z) {
         TEBase TE = getTileEntity(iba, x, y, z);
         if (TE != null) {


### PR DESCRIPTION
This way tinted blocks are reflected as much in the carpenter's block. If you accept this one, I have an additional PR I will submit to add further compatibility with specially coded blocks (in my case GeoStrata opal).