### PR TITLE
Create IWrappableBlock

### DIFF
--- a/src/main/java/com/carpentersblocks/api/IWrappableBlock
+++ b/src/main/java/com/carpentersblocks/api/IWrappableBlock
@@ -1,0 +1,43 @@
+
+/** Implement this on your block class to gain full control over the way it behaves as used as a Carpenter's Blocks
+cover, or to add compatibility that is not otherwise possible.
+public interface IWrappableBlock {
+
+/** Effectively overrides Block.colorMultiplier */
+@SideOnly(Side.CLIENT)
+public int getColorMultiplier(IBlockAccess iba, int x, int y, int z, Block b, int meta);
+
+/** Effectively overrides Block.getIcon */
+@SideOnly(Side.CLIENT)
+public IIcon getIcon(IBlockAccess iba, int x, int y, int z, int side, Block b, int meta);
+
+/** Effectively overrides Block.isProvidingWeakPower */
+public int getWeakRedstone(World world, int x, int y, int z, Block b, int meta);
+
+/** Effectively overrides Block.isProvidingStrongPower */
+public int getStrongRedstone(World world, int x, int y, int z, Block b, int meta);
+
+/** Effectively overrides Block.getHardness */
+public float getHardness(World world, int x, int y, int z, Block b, int meta);
+
+/** Effectively overrides Block.getExplosionResistance */
+public float getBlastResistance(Entity entity, World world, int x, int y, int z, double explosionX, double explosionY, double explosionZ, Block b, int meta);
+
+/** Effectively overrides Block.getFlammability */
+public int getFlammability(IBlockAccess iba, int x, int y, int z, ForgeDirection side, Block b, int meta);
+
+/** Effectively overrides Block.getFireSpreadSpeed */
+public int getFireSpread(IBlockAccess iba, int x, int y, int z, ForgeDirection side, Block b, int meta);
+
+/** Effectively overrides Block.isFireSource */
+public boolean sustainsFire(IBlockAccess iba, int x, int y, int z, ForgeDirection side, Block b, int meta);
+
+/** Effectively overrides Block.isWood */
+public boolean isLog(IBlockAccess iba, int x, int y, int z, Block b, int meta);
+
+/** Effectively overrides Block.canEntityDestroy */
+public boolean canEntityDestroy(IBlockAccess iba, int x, int y, int z, Block b, int meta);
+
+
+
+}


### PR DESCRIPTION
Adds a way for blocks that need special compatibility or need or wish to behave differently as a cover than they do as an in-world block.

For example, GeoStrata rock is defined as an ID-meta pair which determines the rock type and rock shape (engraved pattern), and this data is required to determine the return value of things like colorMultiplier (for opal) and blast resistance (for granite and hornfel) and was not previously available due to the wrapping.

Also, not sure why this was split into a separate PR from its corresponding edit.
https://github.com/Mineshopper/carpentersblocks/pull/193