### PR TITLE
Add FML API annotation

### DIFF
--- a/src/main/java/com/carpentersblocks/api/package-info.java
+++ b/src/main/java/com/carpentersblocks/api/package-info.java
@@ -1,0 +1,4 @@
+@API(owner = "CarpentersBlocks", provides = "CarpentersBlocks|API", apiVersion = "3.3.7")
+package net.shadowfacts.yaw.api;
+
+import cpw.mods.fml.common.API;

--- a/src/main/java/com/carpentersblocks/api/package-info.java
+++ b/src/main/java/com/carpentersblocks/api/package-info.java
@@ -1,4 +1,4 @@
 @API(owner = "CarpentersBlocks", provides = "CarpentersBlocks|API", apiVersion = "3.3.7")
-package net.shadowfacts.yaw.api;
+package com.carpentersblocks.api;
 
 import cpw.mods.fml.common.API;


### PR DESCRIPTION
Prevents duplicate class errors if the API is present in multiple places (e.g. Carpenter's Blocks and an addon mod).