### PR TITLE
Fix garge door crash (infinite while loop)

### DIFF
--- a/src/main/java/com/carpentersblocks/data/GarageDoor.java
+++ b/src/main/java/com/carpentersblocks/data/GarageDoor.java
@@ -195,7 +195,7 @@ public class GarageDoor extends AbstractMultiBlock implements ISided {
             } else if (temp2 != null && getDirection(temp2).equals(axis)) {
                 return temp2;
             }
-        } while (world.getBlock(x, --y, z).equals(Blocks.air));
+        } while (y > 0 && world.getBlock(x, --y, z).equals(Blocks.air));
 
         return null;
     }


### PR DESCRIPTION
If you place the door in place without the surface from below, the server to stop. For example, I placed the door in the End.

![2017-02-04_19 10 48](https://cloud.githubusercontent.com/assets/6772452/22620174/21883abc-eb0e-11e6-828b-e85af1101b3a.png)