### PR TITLE
Fixed Block placing checks for CarpentersBlock and CollapsibleBlock

### DIFF
--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersBlock.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersBlock.java
@@ -142,6 +142,15 @@ public class BlockCarpentersBlock extends BlockSided {
 
     @Override
     /**
+     * Checks to see if you can place this block can be placed on that side of a block: BlockLever overrides
+     */
+    public boolean canPlaceBlockOnSide(World world, int x, int y, int z, int side)
+    {
+        return canPlaceBlockAt(world, x, y, z);
+    }
+
+    @Override
+    /**
      * Checks if the block is a solid face on the given side, used by placement logic.
      */
     public boolean isSideSolid(IBlockAccess blockAccess, int x, int y, int z, ForgeDirection side)

--- a/src/main/java/com/carpentersblocks/block/BlockCarpentersCollapsibleBlock.java
+++ b/src/main/java/com/carpentersblocks/block/BlockCarpentersCollapsibleBlock.java
@@ -251,18 +251,7 @@ public class BlockCarpentersCollapsibleBlock extends BlockSided {
      */
     public boolean canPlaceBlockOnSide(World world, int x, int y, int z, int side)
     {
-        if (!canAttachToSide(side)) {
-            ForgeDirection VALID_SIDES[] = { ForgeDirection.DOWN, ForgeDirection.UP };
-            for (ForgeDirection dir : VALID_SIDES) {
-                // If side is not supported, check that either the block above or below CAN support it
-                if (world.getBlock(x - dir.offsetX, y - dir.offsetY, z - dir.offsetZ).isSideSolid(world, x - dir.offsetX, y - dir.offsetY, z - dir.offsetZ, dir)) {
-                    return true;
-                }
-            }
-            return false;
-        } else {
-            return true;
-        }
+        return canPlaceBlockAt(world, x, y, z);
     }
 
     @Override
@@ -273,11 +262,11 @@ public class BlockCarpentersCollapsibleBlock extends BlockSided {
     {
         super.onBlockPlacedBy(world, x, y, z, entityLiving, itemStack);
 
-        // If sneaking, skip auto-setting quadrant depths
+        TEBase TE = getTileEntity(world, x, y, z);
 
+        // If sneaking, skip auto-setting quadrant depths
         if (!entityLiving.isSneaking())
         {
-            TEBase TE = getTileEntity(world, x, y, z);
             if (TE != null)
             {
                 // Create a linear slope from neighbor blocks and collapsible quadrants
@@ -358,6 +347,13 @@ public class BlockCarpentersCollapsibleBlock extends BlockSided {
                     smoothAdjacentCollapsibles(TE, quad);
                 }
             }
+        }
+        else
+        {
+            Collapsible.setQuadDepth(TE, Collapsible.QUAD_XZNN, 16, false);
+            Collapsible.setQuadDepth(TE, Collapsible.QUAD_XZNP, 16, false);
+            Collapsible.setQuadDepth(TE, Collapsible.QUAD_XZPP, 16, false);
+            Collapsible.setQuadDepth(TE, Collapsible.QUAD_XZPN, 16, false);
         }
     }
 


### PR DESCRIPTION
Hi,

I also had the issue #380 and since there was no answer to that I thought I look a bit into this by myself.

In this pull request if have changed two things. The first is the CarpentersBlocks method for checking wether the Block can be placed. I think this was wrong since the change to use BlockSided as base class instead of BlockCoverable.
The second part is for the CollapsibleBlock.
I also couldn't place this block onto a carpenter slab or stair - the same as for the CarpentersBlock. So I also changed this method. But here I'm not sure if this is ok, since the original code there indicates that it was somehow intended this way. Still it's annoying if you want to use this block to create a slope from the back of carpenter stairs to slabs where I wanted to use it. It will not always set the correct slope automatically but at least it can be placed and corrected then.

Additionally I found that if you are crouching and place the Block it is always placed with 0 height but I think it should be the full block height then.

I hope this changes are ok and if not all then at least some of them maybe makes the correct fix easier for you.