### PR TITLE
Fixed Texture Problem/blockCarpentersBlock Registry Name

### DIFF
--- a/src/main/java/com/carpentersblocks/CarpentersBlocks.java
+++ b/src/main/java/com/carpentersblocks/CarpentersBlocks.java
@@ -13,6 +13,7 @@ import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.network.FMLEventChannel;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 
+@SuppressWarnings("unused")
 @Mod(
         modid = CarpentersBlocks.MOD_ID,
         name = "Carpenter's Blocks",
@@ -24,10 +25,10 @@ public class CarpentersBlocks
     public static final String MOD_ID = "carpentersblocks";
     public static final CreativeTabs CREATIVE_TAB = new CarpentersBlocksTab(MOD_ID);
     public static FMLEventChannel channel;
-    
+
     @SidedProxy(clientSide = "com.carpentersblocks.proxy.ClientProxy", serverSide = "com.carpentersblocks.proxy.CommonProxy")
     public static CommonProxy proxy;
-        
+
     @EventHandler
     public void preInit(FMLPreInitializationEvent event)
     {
@@ -41,7 +42,7 @@ public class CarpentersBlocks
             config.save();
         }
     }
-    
+
     @EventHandler
     public void init(FMLInitializationEvent event) {
     	proxy.init(event);

--- a/src/main/java/com/carpentersblocks/proxy/ClientProxy.java
+++ b/src/main/java/com/carpentersblocks/proxy/ClientProxy.java
@@ -19,7 +19,7 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void preInit(FMLPreInitializationEvent event, Configuration config) {
     	super.preInit(event, config);
-        ModelLoaderRegistry.registerLoader(new ModelLoader());        
+        ModelLoaderRegistry.registerLoader(new ModelLoader());
     }
     
     @Override

--- a/src/main/java/com/carpentersblocks/util/registry/BlockRegistry.java
+++ b/src/main/java/com/carpentersblocks/util/registry/BlockRegistry.java
@@ -20,6 +20,8 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.ShapedOreRecipe;
 
+import static com.carpentersblocks.CarpentersBlocks.MOD_ID;
+
 public class BlockRegistry {
 	
 	private static final Material material = Material.WOOD;
@@ -128,7 +130,7 @@ public class BlockRegistry {
         
     	blockCarpentersBlock = new BlockCarpentersBlock(material)
     		.setUnlocalizedName("blockCarpentersBlock")
-        	.setRegistryName(REGISTRY_NAME_BLOCK)
+            .setRegistryName(MOD_ID + ":" + REGISTRY_NAME_BLOCK)
         	.setHardness(0.2F)
             .setCreativeTab(CarpentersBlocks.CREATIVE_TAB);
         GameRegistry.register(blockCarpentersBlock);


### PR DESCRIPTION
I don't get this problem when running the latest 1.10.2 release, but when running the minecraft client run profile in Intellij Idea, none of the textures for anything would show up, and instead show the default purple/black texture. This fixes that. This also gives blockCarpentersBlock a proper registry name.