### PR TITLE
Fix server crash when safe are broken by other player during usage

### DIFF
--- a/src/main/java/com/carpentersblocks/tileentity/TECarpentersSafe.java
+++ b/src/main/java/com/carpentersblocks/tileentity/TECarpentersSafe.java
@@ -7,6 +7,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import com.carpentersblocks.data.Safe;
+import net.minecraft.tileentity.TileEntity;
 
 public class TECarpentersSafe extends TEBase implements ISidedInventory {
 
@@ -187,7 +188,9 @@ public class TECarpentersSafe extends TEBase implements ISidedInventory {
     @Override
     public boolean isUseableByPlayer(EntityPlayer entityPlayer)
     {
-        if (entityPlayer.getEntityWorld().getTileEntity(xCoord, yCoord, zCoord).equals(this)) {
+        TileEntity tileEntity = entityPlayer.getEntityWorld().getTileEntity(xCoord, yCoord, zCoord);
+
+        if(tileEntity != null && tileEntity.equals(this)) {
             return entityPlayer.getDistanceSq(xCoord + 0.5D, yCoord + 0.5D, zCoord + 0.5D) <= 64.0D;
         }
 


### PR DESCRIPTION
```
java.lang.NullPointerException: Ticking entity
	at com.carpentersblocks.tileentity.TECarpentersSafe.func_70300_a(TECarpentersSafe.java:190)
	at net.minecraft.inventory.ContainerChest.func_75145_c(ContainerChest.java:94)
	at net.minecraftforge.event.entity.player.PlayerOpenContainerEvent.<init>(PlayerOpenContainerEvent.java:27)
	at net.minecraftforge.common.ForgeHooks.canInteractWith(ForgeHooks.java:448)
	at net.minecraft.entity.player.EntityPlayerMP.func_70071_h_(EntityPlayerMP.java:319)
```